### PR TITLE
try to fix language name when printing error message

### DIFF
--- a/openvalidation-generation/src/main/java/io/openvalidation/generation/OpenValidationGenerator.java
+++ b/openvalidation-generation/src/main/java/io/openvalidation/generation/OpenValidationGenerator.java
@@ -53,12 +53,12 @@ public class OpenValidationGenerator implements IOpenValidationGenerator {
         if (template.equalsIgnoreCase("main"))
           throw new OpenValidationException(
               "Generation of '"
-                  + language
+                  + language.getName()
                   + "' Language is not implemented. Missing main.hbs template.");
         else
           throw new OpenValidationException(
               "Generation of '"
-                  + language
+                  + language.getName()
                   + "' Language failed. Missing '"
                   + templateFile
                   + "' template.");


### PR DESCRIPTION


## Description
I noticed this when implementing the rust codegen target, in the error message, the name of the codegen language was mostly gibberish, probably the address the language object and not the string representation of the name of the language.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause compatibility issues)
- [ ] DevOps change (fix or alteration in a build pipeline or config file)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added the upcoming release notes accordingly.
