### PR TITLE
set default value of generated_class_namespace to io.openvalidation.rules

### DIFF
--- a/openvalidation-cli/src/main/java/io/openvalidation/cli/CLIApplication.java
+++ b/openvalidation-cli/src/main/java/io/openvalidation/cli/CLIApplication.java
@@ -72,6 +72,18 @@ public class CLIApplication {
       return false;
     }
 
+    if ((options.language.getShortName().equals("java")
+            || options.language.getShortName().equals("cs"))
+        && (options.params == null || !options.params.contains("model_type"))) {
+      this.messages.add(
+          "missing argument --params(-p) model_type=xxx. an output language '"
+              + options.language.getName()
+              + "' requires a model type of external model.  \n\n");
+
+      ProcessLogger.error(ProcessLogger.CLI_VALIDATE_ARGS);
+      return false;
+    }
+
     ProcessLogger.success(ProcessLogger.CLI_VALIDATE_ARGS);
     return true;
   }

--- a/openvalidation-cli/src/test/java/End2EndTest.java
+++ b/openvalidation-cli/src/test/java/End2EndTest.java
@@ -70,7 +70,9 @@ public class End2EndTest {
 
     if (schema == null) schema = "";
 
-    CLIOptions inputOptions = this.getOptions("-r", rule, "-c", "en", "-s", schema);
+    CLIOptions inputOptions =
+        this.getOptions(
+            "-r", rule, "-c", "en", "-s", schema, "-p", "model_type=io.openvalidation.model");
     CLIApplication app = new CLIApplication(OpenValidation.createDefault(), inputOptions);
 
     OpenValidationResult result = app.run();

--- a/openvalidation-generation/src/main/java/io/openvalidation/generation/OpenValidationGenerator.java
+++ b/openvalidation-generation/src/main/java/io/openvalidation/generation/OpenValidationGenerator.java
@@ -66,6 +66,7 @@ public class OpenValidationGenerator implements IOpenValidationGenerator {
 
       // set default params
       ast.setDefault("generated_class_name", "HUMLValidator");
+      ast.setDefault("generated_class_namespace", "io.openvalidation.rules");
 
       String code = CodeGenerator.generate(language.getName().toLowerCase(), template, ast, false);
 


### PR DESCRIPTION
If the parameter -p and the values contained therein are not entered, incomplete code is generated. See Issue #65.

Strong typed languages like Java or CSharp always require the input of a package or a namespace. These parameters are transferred as follows:

    -p model_type=io.openvalidation.Data;generated_class_namespace=io.openvalidation.rules;generated_class_name=MyRuleSet

see more:
https://docs.openvalidation.io/openvalidation-cli#params

Some of these inputs can be simply preset with defaults, e.g. generated_class_namespace or class_name.

However, the parameter model_type should be defined as a mandatory parameter, since it contains the name of an external model type that cannot be set by default.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause compatibility issues)
- [ ] DevOps change (fix or alteration in a build pipeline or config file)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added the upcoming release notes accordingly.
